### PR TITLE
Small fix for git versioner

### DIFF
--- a/builtins/git.tape
+++ b/builtins/git.tape
@@ -7,6 +7,10 @@ versioner git :: repo ref {
   # This is perhaps more accurately called the "expected" version
   action repo_version > version {
     if [[ "$ref" == "HEAD" ]]; then
+      # ls-remote may return several lines, so we grep for the one we're
+      # actually interested in.
+      # Example: There may be multiple HEADs, the one of the local (queried)
+      # repository and the one of a remote repository.
       git ls-remote $repo $ref | grep -E "^[0-9a-f]+\s+$ref\$" | cut -f1 > $version
     else
       echo "$ref" > $version


### PR DESCRIPTION
Since git ls-remote may return several lines, I think there is a chance that the wrong version is selected in the git versioner’s repo_version action.

For instance, on my local ducttape repository, the command `git ls-remote . HEAD` returns commits for both `HEAD` and `refs/remotes/origin/HEAD`.

While the current version seems to work anyway, I’ve added a grep statement to the line in question to make sure only one line is returned.
